### PR TITLE
Add environment setup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ obj/
 # OS
 .DS_Store
 Thumbs.db
+packages-microsoft-prod.deb

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@ A full-stack web app using:
 - Real-time sync
 - CORS enabled
 
+## Setup
+Run the helper script to install .NET, Node.js and Vite:
+
+```bash
+./scripts/setup.sh
+```
+
 ## Getting Started
 
 ```bash
@@ -21,3 +28,4 @@ dotnet run
 cd frontend/inventory-ui
 npm install
 npm run dev
+```

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+# Install .NET SDK if missing
+if ! command -v dotnet >/dev/null 2>&1; then
+  echo "Installing .NET SDK..."
+  wget -q https://packages.microsoft.com/config/debian/12/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+  sudo dpkg -i packages-microsoft-prod.deb
+  rm packages-microsoft-prod.deb
+  sudo apt-get update
+  sudo apt-get install -y dotnet-sdk-9.0
+fi
+
+# Install Node.js and npm if missing
+if ! command -v npm >/dev/null 2>&1; then
+  echo "Installing Node.js and npm..."
+  sudo apt-get update
+  sudo apt-get install -y nodejs npm
+fi
+
+# Install Vite globally if missing
+if ! command -v vite >/dev/null 2>&1; then
+  echo "Installing Vite..."
+  sudo npm install -g vite
+fi
+
+echo "All dependencies installed"


### PR DESCRIPTION
## Summary
- automate installation of `dotnet` and `vite`
- document the setup step in the README
- ignore temporary package file used by the setup script

## Testing
- `bash scripts/setup.sh` *(fails: `dotnet` not found because this environment doesn't have network access)*
- `npm run build` in `frontend/inventory-ui` *(fails: `vite: not found`)*