### PR TITLE
Use env variable for API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,9 @@ dotnet run
 
 cd frontend/inventory-ui
 npm install
+# copy .env.example to .env and update the value if your backend runs elsewhere
 npm run dev
 ```
+
+The `.env` file in `frontend/inventory-ui` defines `VITE_API_URL`.
+Edit this value to point the React app at a different backend server.

--- a/frontend/inventory-ui/.env.example
+++ b/frontend/inventory-ui/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5204/api

--- a/frontend/inventory-ui/README.md
+++ b/frontend/inventory-ui/README.md
@@ -48,7 +48,12 @@ export default tseslint.config({
     // other rules...
     // Enable its recommended typescript rules
     ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
+  ...reactDom.configs.recommended.rules,
   },
 })
 ```
+
+## Configuration
+
+Copy `.env.example` to `.env` and set `VITE_API_URL` to the base address of
+your backend API. The React app will use this value when making requests.

--- a/frontend/inventory-ui/src/Components/OrderForm.tsx
+++ b/frontend/inventory-ui/src/Components/OrderForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import axios from 'axios'
+import { API_URL } from '../api'
 import type { Product } from '../types/Product'
 
 type Props = {
@@ -12,7 +13,7 @@ const OrderForm = ({ products, onAdd }: Props) => {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    await axios.post('http://localhost:5204/api/orders', form)
+    await axios.post(`${API_URL}/orders`, form)
     alert('✅ Order placed!')
     setForm({ productId: products[0]?.productId ?? 0, quantity: 1 })
     onAdd()

--- a/frontend/inventory-ui/src/Components/ProductForm.tsx
+++ b/frontend/inventory-ui/src/Components/ProductForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import axios from 'axios'
+import { API_URL } from '../api'
 import type { Product } from '../types/Product'
 
 type Props = {
@@ -25,7 +26,7 @@ const ProductForm = ({ onAdd }: Props) => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
-      await axios.post('http://localhost:5204/api/products', form)
+      await axios.post(`${API_URL}/products`, form)
       alert('✅ Product added!')
       setForm({ name: '', sku: '', stock: 0, reorderLevel: 0 })
       onAdd() // 🔁 trigger parent to refetch product list

--- a/frontend/inventory-ui/src/api.ts
+++ b/frontend/inventory-ui/src/api.ts
@@ -1,0 +1,1 @@
+export const API_URL: string = import.meta.env.VITE_API_URL;

--- a/frontend/inventory-ui/src/pages/Dashboard.tsx
+++ b/frontend/inventory-ui/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import axios from 'axios'
+import { API_URL } from '../api'
 import type { Product } from '../types/Product'
 import type { Order } from '../types/Order'
 import ProductForm from '../Components/ProductForm'
@@ -16,7 +17,7 @@ const Dashboard = () => {
   const fetchProducts = async () => {
     try {
       setLoading(true)
-      const res = await axios.get<Product[]>('http://localhost:5204/api/products')
+      const res = await axios.get<Product[]>(`${API_URL}/products`)
       setProducts(res.data)
     } catch (err) {
       console.error('❌ Failed to fetch products', err)
@@ -26,7 +27,7 @@ const Dashboard = () => {
   }
 
   const fetchOrders = async () => {
-    const res = await axios.get<Order[]>('http://localhost:5204/api/orders')
+    const res = await axios.get<Order[]>(`${API_URL}/orders`)
     setOrders(res.data)
   }
 
@@ -46,7 +47,7 @@ const Dashboard = () => {
 
   const handleDelete = async (id: number) => {
     if (!confirm('Delete this product?')) return
-    await axios.delete(`http://localhost:5204/api/products/${id}`)
+    await axios.delete(`${API_URL}/products/${id}`)
     fetchProducts()
   }
 
@@ -60,7 +61,7 @@ const Dashboard = () => {
     const reorderLevel = prompt('Reorder Level', String(p.reorderLevel))
     if (reorderLevel === null) return
 
-    await axios.put(`http://localhost:5204/api/products/${p.productId}`, {
+    await axios.put(`${API_URL}/products/${p.productId}`, {
       productId: p.productId,
       name,
       sku,


### PR DESCRIPTION
## Summary
- make API URL configurable via `VITE_API_URL`
- update React components to use the env based URL
- document env file setup in READMEs

## Testing
- `npm --prefix frontend/inventory-ui install` *(fails: exit handler never called)*