### PR TITLE
Add env vars for DB connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Run the helper script to install .NET, Node.js and Vite:
 
 ```bash
 cd backend/InventoryApi
+# optionally set DB_CONNECTION_STRING to override the default SQL Server connection
 dotnet run
 
 cd frontend/inventory-ui
@@ -33,3 +34,7 @@ npm run dev
 
 The `.env` file in `frontend/inventory-ui` defines `VITE_API_URL`.
 Edit this value to point the React app at a different backend server.
+
+The backend can read its SQL Server connection from the `DB_CONNECTION_STRING`
+environment variable. If not set, it falls back to the connection string in
+`appsettings.json`.

--- a/backend/InventoryApi/Data/AppDbContextFactory.cs
+++ b/backend/InventoryApi/Data/AppDbContextFactory.cs
@@ -11,11 +11,17 @@ namespace InventoryApi.Data
         {
             IConfigurationRoot configuration = new ConfigurationBuilder()
                 .SetBasePath(Directory.GetCurrentDirectory())
-                .AddJsonFile("appsettings.json")
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddEnvironmentVariables()
                 .Build();
 
             var builder = new DbContextOptionsBuilder<AppDbContext>();
             var connectionString = configuration.GetConnectionString("DefaultConnection");
+            var envConnection = configuration["DB_CONNECTION_STRING"];
+            if (!string.IsNullOrEmpty(envConnection))
+            {
+                connectionString = envConnection;
+            }
 
             builder.UseSqlServer(connectionString);
 

--- a/backend/InventoryApi/Program.cs
+++ b/backend/InventoryApi/Program.cs
@@ -3,9 +3,16 @@ using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
-// 🔌 Connect to SQL Server
+// 🔌 Connect to SQL Server (read from config or DB_CONNECTION_STRING env var)
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
+var envConnection = builder.Configuration["DB_CONNECTION_STRING"];
+if (!string.IsNullOrEmpty(envConnection))
+{
+    connectionString = envConnection;
+}
+
 builder.Services.AddDbContext<AppDbContext>(options =>
-    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+    options.UseSqlServer(connectionString));
 
 // 🔐 CORS config (allow all for dev)
 builder.Services.AddCors(options =>

--- a/reports/generate_report.py
+++ b/reports/generate_report.py
@@ -1,9 +1,12 @@
+import os
 import pyodbc
 import pandas as pd
 
-conn = pyodbc.connect(
+conn_str = os.getenv(
+    "DB_CONNECTION_STRING",
     'DRIVER={SQL Server};SERVER=localhost;DATABASE=InventoryDb;Trusted_Connection=yes;'
 )
+conn = pyodbc.connect(conn_str)
 
 query = "SELECT Name, SKU, Stock FROM Products"
 df = pd.read_sql(query, conn)


### PR DESCRIPTION
## Summary
- allow override of connection string via `DB_CONNECTION_STRING`
- support env var in migrations factory
- generate reports using env var for DB connection
- document the new environment variable

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*