### PR TITLE
Integrate reporting with backend API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,17 @@ Edit this value to point the React app at a different backend server.
 The backend can read its SQL Server connection from the `DB_CONNECTION_STRING`
 environment variable. If not set, it falls back to the connection string in
 `appsettings.json`.
+
+## Reports
+
+The backend exposes `GET /api/reports/inventory` which returns the current
+inventory as a CSV file. A small helper script is provided to fetch this data
+and save it locally.
+
+```bash
+pip install -r reports/requirements.txt
+python reports/generate_report.py
+```
+
+Set `API_BASE_URL` if your backend runs on a different URL (defaults to
+`http://localhost:5204`).

--- a/backend/InventoryApi/Controllers/ReportsController.cs
+++ b/backend/InventoryApi/Controllers/ReportsController.cs
@@ -1,0 +1,36 @@
+using InventoryApi.Data;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using System.Text;
+
+namespace InventoryApi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ReportsController : ControllerBase
+    {
+        private readonly AppDbContext _context;
+
+        public ReportsController(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet("inventory")]
+        public async Task<IActionResult> InventoryReport()
+        {
+            var products = await _context.Products
+                .Select(p => new { p.Name, p.SKU, p.Stock })
+                .ToListAsync();
+
+            var csv = new StringBuilder();
+            csv.AppendLine("Name,SKU,Stock");
+            foreach (var p in products)
+            {
+                csv.AppendLine($"{p.Name},{p.SKU},{p.Stock}");
+            }
+
+            return File(Encoding.UTF8.GetBytes(csv.ToString()), "text/csv", "inventory_report.csv");
+        }
+    }
+}

--- a/reports/generate_report.py
+++ b/reports/generate_report.py
@@ -1,15 +1,15 @@
 import os
-import pyodbc
 import pandas as pd
+import requests
 
-conn_str = os.getenv(
-    "DB_CONNECTION_STRING",
-    'DRIVER={SQL Server};SERVER=localhost;DATABASE=InventoryDb;Trusted_Connection=yes;'
-)
-conn = pyodbc.connect(conn_str)
+api_base = os.getenv("API_BASE_URL", "http://localhost:5204")
+url = f"{api_base.rstrip('/')}/api/products"
 
-query = "SELECT Name, SKU, Stock FROM Products"
-df = pd.read_sql(query, conn)
+response = requests.get(url, timeout=10)
+response.raise_for_status()
+
+products = response.json()
+df = pd.DataFrame(products)[["name", "sku", "stock"]]
 df.to_csv("inventory_report.csv", index=False)
 
 print("Report generated: inventory_report.csv")

--- a/reports/requirements.txt
+++ b/reports/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+requests


### PR DESCRIPTION
## Summary
- expose a ReportsController in the API that returns inventory data as CSV
- rewrite `generate_report.py` to call the API instead of hitting SQL directly
- document how to fetch reports and install Python dependencies
- add `reports/requirements.txt` for Python helpers

## Testing
- `dotnet build` *(fails: command not found)*