### PR TITLE
Add Docker Compose stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ Edit this value to point the React app at a different backend server.
 The backend can read its SQL Server connection from the `DB_CONNECTION_STRING`
 environment variable. If not set, it falls back to the connection string in
 `appsettings.json`.
+## Docker Compose
+Run the entire stack with Docker Compose:
+```bash
+docker-compose up --build
+```
+This will start SQL Server, the backend, and the frontend on http://localhost:5173.
+
 
 ## Database Setup
 1. Ensure a running SQL Server instance.

--- a/backend/InventoryApi/Dockerfile
+++ b/backend/InventoryApi/Dockerfile
@@ -1,0 +1,10 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY . .
+RUN dotnet publish -c Release -o /app
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0
+WORKDIR /app
+COPY --from=build /app .
+EXPOSE 5204
+ENTRYPOINT ["dotnet", "InventoryApi.dll"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+services:
+  sqlserver:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=Your_password123
+    ports:
+      - "1433:1433"
+    volumes:
+      - sqlserver-data:/var/opt/mssql
+  backend:
+    build: ./backend/InventoryApi
+    environment:
+      - DB_CONNECTION_STRING=Server=sqlserver;Database=InventoryDb;User=sa;Password=Your_password123;TrustServerCertificate=True;
+      - ASPNETCORE_URLS=http://0.0.0.0:5204
+    ports:
+      - "5204:5204"
+    depends_on:
+      - sqlserver
+  frontend:
+    build: ./frontend/inventory-ui
+    environment:
+      - VITE_API_URL=http://backend:5204/api
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
+volumes:
+  sqlserver-data:

--- a/frontend/inventory-ui/Dockerfile
+++ b/frontend/inventory-ui/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host"]


### PR DESCRIPTION
## Summary
- create Dockerfile for backend and frontend
- add `docker-compose.yml` to orchestrate sqlserver, backend and frontend
- document Compose usage in README

## Testing
- `npm --version`
